### PR TITLE
Fix/prod bugs

### DIFF
--- a/src/Handler/Marketplace.hs
+++ b/src/Handler/Marketplace.hs
@@ -313,10 +313,10 @@ getPackageListR = do
                 $  searchServices category query
                 .| collateVersions
                 .| zipCategories
-                        -- empty list since there are no requested packages in this case
-                .| filterLatestVersionFromSpec []
                 .| filterPkgOsCompatible osPredicate
-                        -- pages start at 1 for some reason. TODO: make pages start at 0
+                -- empty list since there are no requested packages in this case
+                .| filterLatestVersionFromSpec []
+                -- pages start at 1 for some reason. TODO: make pages start at 0
                 .| (dropC (limit' * (page - 1)) *> takeC limit')
                 .| sinkList
         Just packages' -> do
@@ -328,8 +328,8 @@ getPackageListR = do
                 $  getPkgData (packageReqId <$> packages')
                 .| collateVersions
                 .| zipCategories
-                .| filterLatestVersionFromSpec vMap
                 .| filterPkgOsCompatible osPredicate
+                .| filterLatestVersionFromSpec vMap
                 .| sinkList
     -- NOTE: if a package's dependencies do not meet the system requirements, it is currently omitted from the list
     pkgsWithDependencies <- runDB $ mapConcurrently (getPackageDependencies osPredicate) filteredPackages

--- a/src/Handler/Types/Marketplace.hs
+++ b/src/Handler/Types/Marketplace.hs
@@ -155,6 +155,12 @@ data PackageMetadata = PackageMetadata
     , packageMetadataPkgVersion        :: !Version
     }
     deriving (Eq, Show)
+data PackageMetadataIntermediary = PackageMetadataIntermediary
+    { packageMetadataIntermediaryPkgId             :: !PkgId
+    , packageMetadataIntermediaryPkgVersionRecords :: ![Entity VersionRecord]
+    , packageMetadataIntermediaryPkgCategories     :: ![Entity Category]
+    }
+    deriving (Eq, Show)
 data PackageDependencyMetadata = PackageDependencyMetadata
     { packageDependencyMetadataPkgDependencyRecord :: !(Entity PkgDependency)
     , packageDependencyMetadataDepPkgRecord        :: !(Entity PkgRecord)


### PR DESCRIPTION
Fixes: 
- Package manifest returning as latest on registry - this is because versions compatible with eOS were being filtered *after* we determined the latest version possible from the requested spec. 
- Incorrect parsing of "per-page" query param resulting in the default value of 20 always being used - once we reached >20 services, some were not being returned. 