### PR TITLE
Updates/pkg hardware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ version
 **/*.s9pk
 **/appmgr
 0.3.0_features.md
+**/start-sdk
 **/embassy-sdk
 start9-registry.prof
 start9-registry.hp

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ shell.nix
 testdata/
 lbuild.sh
 icon
+resources/apps/text-generation-webui

--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,4 @@ profile:
 cabal:
 	cabal build
 	# this step is specific for m1 devices ie. aarch64-osx
-	sudo cp dist-newstyle/build/aarch64-osx/ghc-9.2.5/start9-registry-0.2.1/x/embassy-publish/build/embassy-publish/embassy-publish /usr/local/bin/
+	sudo cp dist-newstyle/build/aarch64-osx/ghc-9.2.5/start9-registry-0.2.1/x/registry-publish/build/registry-publish/registry-publish /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ cd registry
 ```
 - run `make`
 
-### Set up embassy-publish tool
+### Set up registry-publish tool
 
 - run `apt install libgmp-dev zlib1g-dev libtinfo-dev libpq-dev` (on macOS `brew install libmpd zlib-ng libtiff`)
 - run `stack install` (recommended: include the installation path in your $PATH after running this command)
 - update your shell to include the installation path of the copied executables from `stack install`. i.e. `nano ~./zshrc` add `export PATH=$PATH:/your/path/here` to zshrc; save and exit nano. Run `source ~/.zshrc`
-- run `embassy-publish init --bash` (or --zsh / --fish depending on your preferred shell)
-- run `embassy-publish reg add -l <URL> -n <NAME> -u <USER> -p <PASS>` (include https:// in your URL)
+- run `registry-publish init --bash` (or --zsh / --fish depending on your preferred shell)
+- run `registry-publish reg add -l <URL> -n <NAME> -u <USER> -p <PASS>` (include https:// in your URL)
 - take the hash that is emitted by this command and submit it to the registry owner
 
 ### Setting up a registry dev environment
@@ -40,8 +40,8 @@ cd registry
 - set PG_PASSWORD to the password for that user
 - set SSL_AUTO to false
 - set RESOURCES_PATH to an empty directory you wish to use as your package repository
-- install `embassy-sdk`
-- set STATIC_BIN to the path that contains `embassy-sdk`
+- install `start-sdk`
+- set STATIC_BIN to the path that contains `start-sdk`
 
 ## APIs
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,7 +19,7 @@ ip-from-header: "_env:YESOD_IP_FROM_HEADER:false"
 # In development, they default to the inverse.
 #
 detailed-logging: true
-# should-log-all: false
+should-log-all: true
 # reload-templates: false
 # mutable-static: false
 # skip-combining: false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,7 +19,7 @@ ip-from-header: "_env:YESOD_IP_FROM_HEADER:false"
 # In development, they default to the inverse.
 #
 detailed-logging: true
-should-log-all: true
+# should-log-all: true
 # reload-templates: false
 # mutable-static: false
 # skip-combining: false

--- a/hie.yaml
+++ b/hie.yaml
@@ -7,4 +7,4 @@ cradle:
     - path: "./test"
       component: "start9-registry:test:start9-registry-test"
     - path: "./cli"
-      component: "start9-registry:exe:embassy-publish"
+      component: "start9-registry:exe:registry-publish"

--- a/package.yaml
+++ b/package.yaml
@@ -111,7 +111,7 @@ executables:
     when:
       - condition: flag(library-only)
         buildable: false
-  embassy-publish:
+  registry-publish:
     source-dirs: cli
     main: Main.hs
     ghc-options:

--- a/package.yaml
+++ b/package.yaml
@@ -11,6 +11,7 @@ dependencies:
   - base >=4.12 && <5
   - base64
   - aeson
+  - aeson-pretty
   - ansi-terminal
   - attoparsec
   - bytestring

--- a/package.yaml
+++ b/package.yaml
@@ -63,6 +63,7 @@ dependencies:
   - unliftio
   - unordered-containers
   - unix
+  - utility-ht
   - wai
   - wai-cors
   - wai-extra

--- a/package.yaml
+++ b/package.yaml
@@ -11,7 +11,6 @@ dependencies:
   - base >=4.12 && <5
   - base64
   - aeson
-  - aeson-pretty
   - ansi-terminal
   - attoparsec
   - bytestring

--- a/package.yaml
+++ b/package.yaml
@@ -42,6 +42,7 @@ dependencies:
   - monad-logger
   - monad-logger-extras
   - monad-loops
+  - multimap
   - network-uri
   - optparse-applicative
   - parallel

--- a/package.yaml
+++ b/package.yaml
@@ -53,6 +53,8 @@ dependencies:
   - process
   - protolude
   - rainbow
+  - regex-base
+  - regex-tdfa
   - shakespeare
   - template-haskell
   - terminal-progress-bar

--- a/resources/apps/lnd/0.13.3.1/manifest.json
+++ b/resources/apps/lnd/0.13.3.1/manifest.json
@@ -16,13 +16,13 @@
   "build": [
     "make"
   ],
-    "hardware-requirements" {
+    "hardware-requirements": {
     "device": {
       "processor": "intel",
       "display": "r'^{.*}$'"
     },
     "ram": "8"
-  }
+  },
   "release-notes": "Upgrade to EmbassyOS v0.3.0",
   "license": "mit",
   "wrapper-repo": "https://github.com/Start9Labs/lnd-wrapper",

--- a/resources/apps/lnd/0.13.3.1/manifest.json
+++ b/resources/apps/lnd/0.13.3.1/manifest.json
@@ -16,6 +16,13 @@
   "build": [
     "make"
   ],
+    "hardware-requirements" {
+    "device": {
+      "processor": "intel",
+      "display": "r'^{.*}$'"
+    },
+    "ram": "8"
+  }
   "release-notes": "Upgrade to EmbassyOS v0.3.0",
   "license": "mit",
   "wrapper-repo": "https://github.com/Start9Labs/lnd-wrapper",

--- a/src/Cli/Cli.hs
+++ b/src/Cli/Cli.hs
@@ -529,7 +529,7 @@ upload (Upload name mpkg shouldIndex arches) = do
     noBody <-
         parseRequest ("POST " <> show publishCfgRepoLocation <> "/admin/v0/upload")
             <&> setRequestHeaders [("accept", "text/plain")]
-            <&> setRequestResponseTimeout (responseTimeoutMicro (600_000_000)) -- 10 minutes
+            <&> setRequestResponseTimeout (responseTimeoutMicro (5_400_000_000)) -- 90 minutes
             <&> applyBasicAuth (B8.pack publishCfgRepoUser) (B8.pack publishCfgRepoPass)
     size <- getFileSize pkg
     bar <- newProgressBar defStyle 30 (Progress 0 (fromIntegral size) ())

--- a/src/Cli/Cli.hs
+++ b/src/Cli/Cli.hs
@@ -270,7 +270,7 @@ cfgLocation = getHomeDirectory <&> \d -> d </> ".embassy/publish.dhall"
 
 
 parseInit :: Parser (Maybe Shell)
-parseInit = subparser $ command "init" (info go $ progDesc "Initializes embassy-publish config") <> metavar "init"
+parseInit = subparser $ command "init" (info go $ progDesc "Initializes registry-publish config") <> metavar "init"
     where
         shells = [Bash, Fish, Zsh]
         go = headMay . fmap fst . filter snd . zip shells <$> for shells (switch . long . toS . toLower . show)
@@ -461,13 +461,13 @@ init sh = do
         for_ sh $ \case
             Bash -> do
                 let bashrc = home </> ".bashrc"
-                appendFile bashrc "source <(embassy-publish --bash-completion-script `which embassy-publish`)\n"
+                appendFile bashrc "source <(registry-publish --bash-completion-script `which registry-publish`)\n"
             Fish -> do
                 let fishrc = home </> ".config" </> "fish" </> "config.fish"
-                appendFile fishrc "source <(embassy-publish --fish-completion-script `which embassy-publish`)\n"
+                appendFile fishrc "source <(registry-publish --fish-completion-script `which registry-publish`)\n"
             Zsh -> do
-                let zshcompleter = "/usr/local/share/zsh/site-functions/_embassy-publish"
-                res <- readProcess "embassy-publish" ["--zsh-completion-script", "`which embassy-publish`"] ""
+                let zshcompleter = "/usr/local/share/zsh/site-functions/_registry-publish"
+                res <- readProcess "registry-publish" ["--zsh-completion-script", "`which registry-publish`"] ""
                 writeFile zshcompleter (toS res)
 
 

--- a/src/Cli/Cli.hs
+++ b/src/Cli/Cli.hs
@@ -70,7 +70,7 @@ import Handler.Admin (
     PackageList (..),
  )
 import Lib.External.AppMgr (sourceManifest)
-import Lib.Types.Core (PkgId (..))
+import Lib.Types.Core (PkgId (..), OsArch)
 import Lib.Types.Emver (Version (..))
 import Lib.Types.Manifest (PackageManifest (..))
 import Network.HTTP.Client.Conduit (
@@ -109,7 +109,6 @@ import Options.Applicative (
     help,
     helper,
     info,
-    liftA3,
     long,
     mappend,
     metavar,
@@ -205,12 +204,16 @@ import Yesod (
     logError,
     logWarn,
  )
+import Prelude (read)
+import Options.Applicative (some)
+import Control.Applicative.HT (lift4)
 
 
 data Upload = Upload
     { publishRepoName :: !String
     , publishPkg :: !(Maybe FilePath)
     , publishIndex :: !Bool
+    , publishArches :: !(Maybe [OsArch])
     }
     deriving (Show)
 
@@ -253,7 +256,7 @@ data Command
     | CmdRegDel !String
     | CmdRegList
     | CmdUpload !Upload
-    | CmdIndex !String !String !Version !Bool
+    | CmdIndex !String !String !Version !(Maybe [OsArch]) !Bool
     | CmdListUnindexed !String
     | CmdCatAdd !String !String !(Maybe String) !(Maybe Int)
     | CmdCatDel !String !String
@@ -281,7 +284,7 @@ parsePublish =
                 "upload"
     where
         go =
-            liftA3
+            lift4
                 Upload
                 (strOption (short 't' <> long "target" <> metavar "NAME" <> help "Name of registry in publish.dhall"))
                 ( optional $
@@ -289,7 +292,17 @@ parsePublish =
                         (short 'p' <> long "package" <> metavar "S9PK" <> help "File path of the package to publish")
                 )
                 (switch (short 'i' <> long "index" <> help "Index the package after uploading"))
+                ( optional $
+                    some parseArch 
+                )
 
+parseArch :: Parser OsArch
+parseArch = read <$> strOption
+    ( short 'a'
+    <> long "arches"
+    <> metavar "ARCHES"
+    <> help "Single element of package architectures type. Options include x86_64 and aarch64."
+    )
 
 parseRepoAdd :: Parser Command
 parseRepoAdd = subparser $ command "add" (info go $ progDesc "Add a registry to your config") <> metavar "add"
@@ -349,6 +362,7 @@ parseIndexHelper b =
         <$> strOption (short 't' <> long "target" <> metavar "REGISTRY_NAME")
         <*> strArgument (metavar "PKG")
         <*> strArgument (metavar "VERSION")
+        <*> optional (some parseArch)
         <*> pure b
 
 
@@ -430,7 +444,7 @@ cliMain =
         CmdRegDel s -> regRm s
         CmdRegList -> regLs
         CmdUpload up -> upload up
-        CmdIndex name pkg v shouldIndex -> if shouldIndex then index name pkg v else deindex name pkg v
+        CmdIndex name pkg v arches shouldIndex -> if shouldIndex then index name pkg v arches else deindex name pkg v arches
         CmdListUnindexed name -> listUnindexed name
         CmdCatAdd target cat desc pri -> catAdd target cat desc pri
         CmdCatDel target cat -> catDel target cat
@@ -495,7 +509,7 @@ regLs = do
 
 
 upload :: Upload -> IO ()
-upload (Upload name mpkg shouldIndex) = do
+upload (Upload name mpkg shouldIndex arches) = do
     PublishCfgRepo{..} <- findNameInCfg name
     pkg <- case mpkg of
         Nothing -> do
@@ -539,18 +553,18 @@ upload (Upload name mpkg shouldIndex) = do
                 exitWith $ ExitFailure 1
             Right a -> pure a
         let pkgId = toS $ unPkgId packageManifestId
-        index name pkgId packageManifestVersion
+        index name pkgId packageManifestVersion arches
         putChunkLn $ fromString ("Successfully indexed " <> pkgId <> "@" <> show packageManifestVersion) & fore green
     where
         sfs2prog :: StreamFileStatus -> Progress ()
         sfs2prog StreamFileStatus{..} = Progress (fromIntegral readSoFar) (fromIntegral fileSize) ()
 
-index :: String -> String -> Version -> IO ()
-index name pkg v = performHttp name "POST" [i|/admin/v0/index|] (IndexPkgReq (PkgId $ toS pkg) v)
+index :: String -> String -> Version -> (Maybe [OsArch]) -> IO ()
+index name pkg v arches = performHttp name "POST" [i|/admin/v0/index|] (IndexPkgReq (PkgId $ toS pkg) v arches)
 
 
-deindex :: String -> String -> Version -> IO ()
-deindex name pkg v = performHttp name "POST" [i|/admin/v0/deindex|] (IndexPkgReq (PkgId $ toS pkg) v)
+deindex :: String -> String -> Version -> (Maybe [OsArch]) -> IO ()
+deindex name pkg v arches = performHttp name "POST" [i|/admin/v0/deindex|] (IndexPkgReq (PkgId $ toS pkg) v arches)
 
 
 listUnindexed :: String -> IO ()

--- a/src/Database/Queries.hs
+++ b/src/Database/Queries.hs
@@ -299,9 +299,11 @@ upsertPackageVersionPlatform :: (MonadUnliftIO m) => (Maybe [OsArch]) -> Package
 upsertPackageVersionPlatform maybeArches PackageManifest{..} = do
     now <- liftIO getCurrentTime
     let pkgId = PkgRecordKey packageManifestId
-    let arches = case maybeArches of
+    let arches = case packageHardwareArch of
             Just a -> a
-            Nothing -> [X86_64 .. AARCH64]
+            Nothing -> case maybeArches of
+                Just a -> a
+                Nothing -> [X86_64, AARCH64]
     let records = createVersionPlatformRecord now pkgId packageManifestVersion packageHardwareRam packageHardwareDevice <$> arches 
     repsertMany records
     where

--- a/src/Database/Queries.hs
+++ b/src/Database/Queries.hs
@@ -116,7 +116,7 @@ import Startlude (
     (<$>), Int,
  )
 import Database.Esqueleto.Experimental (isNothing)
-import Database.Esqueleto.Experimental ((>=.))
+import Database.Esqueleto.Experimental ((<=.))
 
 serviceQuerySource ::
     (MonadResource m, MonadIO m) =>
@@ -133,7 +133,7 @@ serviceQuerySource mCat query arches mRam = selectSource $ do
                 `innerJoin` table @PkgRecord `on` (\(v :& _ :& p) -> (PkgRecordId === VersionRecordPkgId) (p :& v))
             where_ (service ^. VersionRecordNumber ==. vp ^. VersionPlatformVersionNumber)
             where_ (vp ^. VersionPlatformArch `in_` (valList arches))
-            where_ (vp ^. VersionPlatformRam >=. val mRam ||. isNothing (vp ^. VersionPlatformRam))
+            where_ (vp ^. VersionPlatformRam <=. val mRam ||. isNothing (vp ^. VersionPlatformRam))
             where_ (pr ^. PkgRecordHidden ==. val False)
             where_ $ queryInMetadata query service
             pure (service, vp)
@@ -150,7 +150,7 @@ serviceQuerySource mCat query arches mRam = selectSource $ do
             where_ $ cat ^. CategoryName ==. val category &&. queryInMetadata query service
             where_ (service ^. VersionRecordNumber ==. vp ^. VersionPlatformVersionNumber)
             where_ (vp ^. VersionPlatformArch `in_` (valList arches))
-            where_ (vp ^. VersionPlatformRam >=. val mRam ||. isNothing (vp ^. VersionPlatformRam))
+            where_ (vp ^. VersionPlatformRam <=. val mRam ||. isNothing (vp ^. VersionPlatformRam))
             where_ (pr ^. PkgRecordHidden ==. val False)
             pure (service, vp)
     orderBy
@@ -173,7 +173,7 @@ getPkgDataSource pkgs arches mRam = selectSource $ do
         `innerJoin` table @VersionPlatform `on` (\(service :& vp) -> (VersionPlatformPkgId === VersionRecordPkgId) (vp :& service))
     where_ (pkgData ^. VersionRecordNumber ==. vp ^. VersionPlatformVersionNumber)
     where_ (vp ^. VersionPlatformArch `in_` (valList arches))
-    where_ (vp ^. VersionPlatformRam >=. val mRam ||. isNothing (vp ^. VersionPlatformRam))
+    where_ (vp ^. VersionPlatformRam <=. val mRam ||. isNothing (vp ^. VersionPlatformRam))
     where_ (pkgData ^. VersionRecordPkgId `in_` valList (PkgRecordKey <$> pkgs))
     pure (pkgData, vp)
 

--- a/src/Database/Queries.hs
+++ b/src/Database/Queries.hs
@@ -116,6 +116,7 @@ import Startlude (
     ($>),
     (<$>), Int,
  )
+import Database.Esqueleto.Experimental ((>.))
 
 serviceQuerySource ::
     (MonadResource m, MonadIO m) =>
@@ -149,7 +150,7 @@ serviceQuerySource mCat query mOsArch mRam = selectSource $ do
             where_ $ cat ^. CategoryName ==. val category &&. queryInMetadata query service
             where_ (service ^. VersionRecordNumber ==. vp ^. VersionPlatformVersionNumber)
             where_ (vp ^. VersionPlatformArch ==. val mOsArch)
-            where_ (vp ^. VersionPlatformRam ==. val mRam)
+            where_ (vp ^. VersionPlatformRam >. val mRam)
             where_ (pr ^. PkgRecordHidden ==. val False)
             pure service
     groupBy (service ^. VersionRecordPkgId, service ^. VersionRecordNumber)

--- a/src/Handler/Admin.hs
+++ b/src/Handler/Admin.hs
@@ -221,7 +221,7 @@ instance FromJSON IndexPkgReq where
     parseJSON = withObject "Index Package Request" $ \o -> do
         indexPkgReqId <- o .: "id"
         indexPkgReqVersion <- o .: "version"
-        indexPkgReqArches <- o .: "arches"
+        indexPkgReqArches <- o .:? "arches"
         pure IndexPkgReq{..}
 instance ToJSON IndexPkgReq where
     toJSON IndexPkgReq{..} = object ["id" .= indexPkgReqId, "version" .= indexPkgReqVersion]

--- a/src/Handler/Admin.hs
+++ b/src/Handler/Admin.hs
@@ -250,7 +250,7 @@ postPkgDeindexR = do
             pure ()
     where
         deleteArch :: PkgId -> Version -> OsArch -> Handler ()
-        deleteArch id v a = runDB $ deleteWhere [VersionPlatformArch ==. a, VersionPlatformVersionNumber ==. v, VersionPlatformPkgId ==. PkgRecordKey id]
+        deleteArch id v a = runDB $ deleteWhere [VersionPlatformArch ==. Just a, VersionPlatformVersionNumber ==. v, VersionPlatformPkgId ==. PkgRecordKey id]
 
 
 newtype PackageList = PackageList {unPackageList :: HashMap PkgId [Version]}

--- a/src/Handler/Admin.hs
+++ b/src/Handler/Admin.hs
@@ -250,7 +250,7 @@ postPkgDeindexR = do
             pure ()
     where
         deleteArch :: PkgId -> Version -> OsArch -> Handler ()
-        deleteArch id v a = runDB $ deleteWhere [VersionPlatformArch ==. Just a, VersionPlatformVersionNumber ==. v, VersionPlatformPkgId ==. PkgRecordKey id]
+        deleteArch id v a = runDB $ deleteWhere [VersionPlatformArch ==. a, VersionPlatformVersionNumber ==. v, VersionPlatformPkgId ==. PkgRecordKey id]
 
 
 newtype PackageList = PackageList {unPackageList :: HashMap PkgId [Version]}

--- a/src/Handler/Admin.hs
+++ b/src/Handler/Admin.hs
@@ -119,7 +119,7 @@ import Startlude (
     (>),
     (&&),
     (||),
-    (<=), traceM
+    (<=),
  )
 import System.FilePath (
     (<.>),

--- a/src/Handler/Admin.hs
+++ b/src/Handler/Admin.hs
@@ -46,7 +46,7 @@ import Database.Persist (
     entityVal,
     insert_,
     selectList,
-    (=.),
+    (=.), PersistQueryWrite (deleteWhere),
  )
 import Database.Persist.Postgresql (runSqlPoolNoTransaction)
 import Database.Queries (upsertPackageVersion, upsertPackageVersionPlatform)
@@ -67,12 +67,12 @@ import Lib.PkgRepository (
     getPackages,
     getVersionsFor,
  )
-import Lib.Types.Core (PkgId (unPkgId))
+import Lib.Types.Core (PkgId (unPkgId), OsArch)
 import Lib.Types.Emver (Version (..))
 import Lib.Types.Manifest (PackageManifest (..))
 import Model (
     Category (..),
-    EntityField (EosHashHash),
+    EntityField (EosHashHash, VersionPlatformArch, VersionPlatformVersionNumber, VersionPlatformPkgId),
     EosHash (EosHash),
     Key (AdminKey, PkgRecordKey, VersionRecordKey),
     PkgCategory (PkgCategory),
@@ -149,6 +149,7 @@ import Yesod.Auth (YesodAuth (maybeAuthId))
 import Yesod.Core.Types (JSONResponse (JSONResponse))
 import Database.Persist.Sql (runSqlPool)
 import Data.List (elem, length)
+import Database.Persist ((==.))
 
 postPkgUploadR :: Handler ()
 postPkgUploadR = do
@@ -213,12 +214,14 @@ postEosUploadR = do
 data IndexPkgReq = IndexPkgReq
     { indexPkgReqId :: !PkgId
     , indexPkgReqVersion :: !Version
+    , indexPkgReqArches :: !(Maybe [OsArch])
     }
     deriving (Eq, Show)
 instance FromJSON IndexPkgReq where
     parseJSON = withObject "Index Package Request" $ \o -> do
         indexPkgReqId <- o .: "id"
         indexPkgReqVersion <- o .: "version"
+        indexPkgReqArches <- o .: "arches"
         pure IndexPkgReq{..}
 instance ToJSON IndexPkgReq where
     toJSON IndexPkgReq{..} = object ["id" .= indexPkgReqId, "version" .= indexPkgReqVersion]
@@ -235,12 +238,19 @@ postPkgIndexR = do
                 [i|Could not locate manifest for #{indexPkgReqId}@#{indexPkgReqVersion}|]
     pool <- getsYesod appConnPool
     runSqlPoolNoTransaction (upsertPackageVersion man) pool Nothing
-    runSqlPool (upsertPackageVersionPlatform man) pool
+    runSqlPool (upsertPackageVersionPlatform indexPkgReqArches man) pool
 
 postPkgDeindexR :: Handler ()
 postPkgDeindexR = do
     IndexPkgReq{..} <- requireCheckJsonBody
-    runDB $ delete (VersionRecordKey (PkgRecordKey indexPkgReqId) indexPkgReqVersion)
+    case indexPkgReqArches of
+        Nothing -> runDB $ delete (VersionRecordKey (PkgRecordKey indexPkgReqId) indexPkgReqVersion)
+        Just a -> do
+            _ <- traverse (deleteArch indexPkgReqId indexPkgReqVersion) a
+            pure ()
+    where
+        deleteArch :: PkgId -> Version -> OsArch -> Handler ()
+        deleteArch id v a = runDB $ deleteWhere [VersionPlatformArch ==. a, VersionPlatformVersionNumber ==. v, VersionPlatformPkgId ==. PkgRecordKey id]
 
 
 newtype PackageList = PackageList {unPackageList :: HashMap PkgId [Version]}

--- a/src/Handler/Admin.hs
+++ b/src/Handler/Admin.hs
@@ -119,7 +119,7 @@ import Startlude (
     (>),
     (&&),
     (||),
-    (<=)
+    (<=), traceM
  )
 import System.FilePath (
     (<.>),
@@ -235,7 +235,7 @@ postPkgIndexR = do
         liftIO (decodeFileStrict manifest)
             `orThrow` sendResponseText
                 status404
-                [i|Could not locate manifest for #{indexPkgReqId}@#{indexPkgReqVersion}|]
+                [i|Could not decode manifest for #{indexPkgReqId}@#{indexPkgReqVersion}|]
     pool <- getsYesod appConnPool
     runSqlPoolNoTransaction (upsertPackageVersion man) pool Nothing
     runSqlPool (upsertPackageVersionPlatform indexPkgReqArches man) pool

--- a/src/Handler/Eos/V0/Latest.hs
+++ b/src/Handler/Eos/V0/Latest.hs
@@ -19,8 +19,8 @@ import Database.Esqueleto.Experimental (
  )
 import Foundation (Handler)
 import Handler.Package.V0.ReleaseNotes (ReleaseNotes (..))
-import Handler.Util (queryParamAs, getArchQuery)
-import Lib.Types.Emver (Version (unVersion), Version(Version), parseVersion)
+import Handler.Util (getOsArch, getOsVersion)
+import Lib.Types.Emver (Version (unVersion), Version(Version))
 import Model (EntityField (..), OsVersion (..))
 import Orphans.Emver ()
 import Startlude (Down (..), Eq, Generic, Maybe (..), Ord ((<)), Text, filter, fst, head, pure, sortOn, ($), (&&&), (.), (<$>), (<&>), (<=))
@@ -48,9 +48,9 @@ instance ToTypedContent EosRes where
 
 getEosVersionR :: Handler (JSONResponse (Maybe EosRes))
 getEosVersionR = do
-    currentEosVersion <- fromMaybe Version { unVersion = (0,3,0,0) } <$> queryParamAs "eos-version" parseVersion
+    currentEosVersion <-  fromMaybe Version { unVersion = (0,3,0,0) } <$> getOsVersion
     -- defaults to raspberrypi for those on OS versions where we did not send this param yet
-    arch <- fromMaybe RASPBERRYPI <$> getArchQuery 
+    arch <- fromMaybe RASPBERRYPI <$> getOsArch 
     allEosVersions <- runDB $
         select $ do
             vers <- from $ table @OsVersion

--- a/src/Handler/Package/V0/Icon.hs
+++ b/src/Handler/Package/V0/Icon.hs
@@ -10,7 +10,7 @@ import Data.String.Interpolate.IsString (
     i,
  )
 import Foundation (Handler)
-import Handler.Package.V1.Index (getOsVersionQuery)
+import Handler.Package.V1.Index (getOsVersionCompat)
 import Handler.Util (
     fetchCompatiblePkgVersions,
     getVersionSpecFromQuery,
@@ -40,7 +40,7 @@ import Yesod (
 
 getIconsR :: PkgId -> Handler TypedContent
 getIconsR pkg = do
-    osVersion <- getOsVersionQuery
+    osVersion <- getOsVersionCompat
     osCompatibleVersions <- fetchCompatiblePkgVersions osVersion pkg
     spec <- getVersionSpecFromQuery
     preferMin <- versionPriorityFromQueryIsMin

--- a/src/Handler/Package/V0/Instructions.hs
+++ b/src/Handler/Package/V0/Instructions.hs
@@ -10,7 +10,7 @@ import Data.String.Interpolate.IsString (
     i,
  )
 import Foundation (Handler)
-import Handler.Package.V1.Index (getOsVersionQuery)
+import Handler.Package.V1.Index (getOsVersionCompat)
 import Handler.Util (
     fetchCompatiblePkgVersions,
     getVersionSpecFromQuery,
@@ -42,7 +42,7 @@ import Yesod (
 getInstructionsR :: PkgId -> Handler TypedContent
 getInstructionsR pkg = do
     spec <- getVersionSpecFromQuery
-    osVersion <- getOsVersionQuery
+    osVersion <- getOsVersionCompat
     osCompatibleVersions <- fetchCompatiblePkgVersions osVersion pkg
     preferMin <- versionPriorityFromQueryIsMin
     version <-

--- a/src/Handler/Package/V0/Latest.hs
+++ b/src/Handler/Package/V0/Latest.hs
@@ -16,7 +16,7 @@ import Lib.Types.Core (PkgId)
 import Lib.Types.Emver (Version (..), satisfies)
 import Model (VersionRecord (..))
 import Network.HTTP.Types (status400)
-import Startlude (Bool (True), Down (Down), Either (..), Generic, Maybe (..), NonEmpty, Show, const, encodeUtf8, filter, flip, nonEmpty, pure, ($), (.), (<$>), (<&>), (>>=), fst, traceM, show)
+import Startlude (Bool (True), Down (Down), Either (..), Generic, Maybe (..), NonEmpty, Show, const, encodeUtf8, filter, flip, nonEmpty, pure, ($), (.), (<$>), (<&>), fst)
 import Yesod (ToContent (..), ToTypedContent (..), YesodPersist (runDB), YesodRequest (reqGetParams), getRequest, sendResponseStatus)
 import Handler.Util (filterDeprecatedVersions, getPkgArch, filterDevices)
 import Yesod.Core (getsYesod)
@@ -39,9 +39,7 @@ getVersionLatestR = do
         getOsVersionCompat <&> \case
             Nothing -> const True
             Just v -> flip satisfies v
-    pkgArch <- getPkgArch >>= \case
-        Nothing -> pure []
-        Just a -> pure a
+    pkgArch <- getPkgArch
     ram <- getRamQuery
     hardwareDevices <- getHardwareDevicesQuery
     communityServiceDeprecationVersion <- getsYesod $ communityVersion . appSettings

--- a/src/Handler/Package/V0/Latest.hs
+++ b/src/Handler/Package/V0/Latest.hs
@@ -10,7 +10,7 @@ import Data.List.NonEmpty.Extra qualified as NE
 import Data.Tuple.Extra (second)
 import Database.Queries (collateVersions, getPkgDataSource)
 import Foundation (Handler, RegistryCtx (appSettings))
-import Handler.Package.V1.Index (getOsVersionQuery)
+import Handler.Package.V1.Index (getOsVersionCompat)
 import Lib.Error (S9Error (..))
 import Lib.Types.Core (PkgId)
 import Lib.Types.Emver (Version (..), satisfies)
@@ -18,7 +18,7 @@ import Model (VersionRecord (..))
 import Network.HTTP.Types (status400)
 import Startlude (Bool (True), Down (Down), Either (..), Generic, Maybe (..), NonEmpty, Show, const, encodeUtf8, filter, flip, nonEmpty, pure, ($), (.), (<$>), (<&>))
 import Yesod (ToContent (..), ToTypedContent (..), YesodPersist (runDB), YesodRequest (reqGetParams), getRequest, sendResponseStatus)
-import Handler.Util (getArchQuery, filterDeprecatedVersions)
+import Handler.Util (getOsArch, filterDeprecatedVersions)
 import Yesod.Core (getsYesod)
 import Settings (AppSettings(communityVersion))
 
@@ -36,10 +36,10 @@ getVersionLatestR :: Handler VersionLatestRes
 getVersionLatestR = do
     getParameters <- reqGetParams <$> getRequest
     osPredicate' <-
-        getOsVersionQuery <&> \case
+        getOsVersionCompat <&> \case
             Nothing -> const True
             Just v -> flip satisfies v
-    osArch <- getArchQuery
+    osArch <- getOsArch
     communityServiceDeprecationVersion <- getsYesod $ communityVersion . appSettings
     do
         case lookup "ids" getParameters of

--- a/src/Handler/Package/V0/Latest.hs
+++ b/src/Handler/Package/V0/Latest.hs
@@ -16,7 +16,7 @@ import Lib.Types.Core (PkgId)
 import Lib.Types.Emver (Version (..), satisfies)
 import Model (VersionRecord (..))
 import Network.HTTP.Types (status400)
-import Startlude (Bool (True), Down (Down), Either (..), Generic, Maybe (..), NonEmpty, Show, const, encodeUtf8, filter, flip, nonEmpty, pure, ($), (.), (<$>), (<&>), (>>=), fst)
+import Startlude (Bool (True), Down (Down), Either (..), Generic, Maybe (..), NonEmpty, Show, const, encodeUtf8, filter, flip, nonEmpty, pure, ($), (.), (<$>), (<&>), (>>=), fst, traceM, show)
 import Yesod (ToContent (..), ToTypedContent (..), YesodPersist (runDB), YesodRequest (reqGetParams), getRequest, sendResponseStatus)
 import Handler.Util (filterDeprecatedVersions, getPkgArch, filterDevices)
 import Yesod.Core (getsYesod)
@@ -63,7 +63,7 @@ getVersionLatestR = do
                                     .| mapC (second (filter (osPredicate' . versionRecordOsVersion . fst)))
                                     -- filter hardware device compatability                        
                                     .| mapMC (\(b,c) -> do 
-                                        l <- filterDevices hardwareDevices pkgArch c
+                                        l <- filterDevices hardwareDevices c
                                         pure (b, l)
                                         )
                                     -- filter out deprecated service versions after community registry release

--- a/src/Handler/Package/V0/License.hs
+++ b/src/Handler/Package/V0/License.hs
@@ -10,7 +10,7 @@ import Data.String.Interpolate.IsString (
     i,
  )
 import Foundation (Handler)
-import Handler.Package.V1.Index (getOsVersionQuery)
+import Handler.Package.V1.Index (getOsVersionCompat)
 import Handler.Util (
     fetchCompatiblePkgVersions,
     getVersionSpecFromQuery,
@@ -41,7 +41,7 @@ import Yesod (
 
 getLicenseR :: PkgId -> Handler TypedContent
 getLicenseR pkg = do
-    osVersion <- getOsVersionQuery
+    osVersion <- getOsVersionCompat
     osCompatibleVersions <- fetchCompatiblePkgVersions osVersion pkg
     spec <- getVersionSpecFromQuery
     preferMin <- versionPriorityFromQueryIsMin

--- a/src/Handler/Package/V0/Manifest.hs
+++ b/src/Handler/Package/V0/Manifest.hs
@@ -10,7 +10,7 @@ import Data.String.Interpolate.IsString (
     i,
  )
 import Foundation (Handler)
-import Handler.Package.V1.Index (getOsVersionQuery)
+import Handler.Package.V1.Index (getOsVersionCompat)
 import Handler.Util (
     addPackageHeader,
     fetchCompatiblePkgVersions,
@@ -42,7 +42,7 @@ import Yesod (
 
 getAppManifestR :: PkgId -> Handler TypedContent
 getAppManifestR pkg = do
-    osVersion <- getOsVersionQuery
+    osVersion <- getOsVersionCompat
     osCompatibleVersions <- fetchCompatiblePkgVersions osVersion pkg
     versionSpec <- getVersionSpecFromQuery
     preferMin <- versionPriorityFromQueryIsMin

--- a/src/Handler/Package/V0/ReleaseNotes.hs
+++ b/src/Handler/Package/V0/ReleaseNotes.hs
@@ -11,7 +11,7 @@ import Data.Aeson.Key (fromText)
 import Data.HashMap.Strict (HashMap)
 import Data.HashMap.Strict qualified as HM
 import Foundation (Handler)
-import Handler.Package.V1.Index (getOsVersionQuery)
+import Handler.Package.V1.Index (getOsVersionCompat)
 import Handler.Util (fetchCompatiblePkgVersions)
 import Lib.Types.Core (PkgId)
 import Lib.Types.Emver (Version)
@@ -49,7 +49,7 @@ instance ToTypedContent ReleaseNotes where
 
 getReleaseNotesR :: PkgId -> Handler ReleaseNotes
 getReleaseNotesR pkg = do
-    osVersion <- getOsVersionQuery
+    osVersion <- getOsVersionCompat
     osCompatibleVersions <- fetchCompatiblePkgVersions osVersion pkg
     pure $ constructReleaseNotesApiRes osCompatibleVersions
     where

--- a/src/Handler/Package/V0/S9PK.hs
+++ b/src/Handler/Package/V0/S9PK.hs
@@ -14,7 +14,7 @@ import Database.Queries (
  )
 import Foundation (Handler)
 import GHC.Show (show)
-import Handler.Package.V1.Index (getOsVersionQuery)
+import Handler.Package.V1.Index (getOsVersionCompat)
 import Handler.Util (
     addPackageHeader,
     fetchCompatiblePkgVersions,
@@ -79,7 +79,7 @@ getAppR file = do
                 Nothing -> sendResponseStatus status416 ("Range Not Satisfiable" :: Text)
                 Just ranges -> pure $ Just ranges
     let pkg = PkgId . T.pack $ takeBaseName (show file)
-    osVersion <- getOsVersionQuery
+    osVersion <- getOsVersionCompat
     osCompatibleVersions <- fetchCompatiblePkgVersions osVersion pkg
     versionSpec <- getVersionSpecFromQuery
     preferMin <- versionPriorityFromQueryIsMin

--- a/src/Handler/Package/V0/Version.hs
+++ b/src/Handler/Package/V0/Version.hs
@@ -11,7 +11,7 @@ import Data.String.Interpolate.IsString (
     i,
  )
 import Foundation (Handler)
-import Handler.Package.V1.Index (getOsVersionQuery)
+import Handler.Package.V1.Index (getOsVersionCompat)
 import Handler.Util (
     fetchCompatiblePkgVersions,
     getVersionSpecFromQuery,
@@ -61,7 +61,7 @@ instance ToTypedContent (Maybe AppVersionRes) where
 
 getPkgVersionR :: PkgId -> Handler AppVersionRes
 getPkgVersionR pkg = do
-    osVersion <- getOsVersionQuery
+    osVersion <- getOsVersionCompat
     osCompatibleVersions <- fetchCompatiblePkgVersions osVersion pkg
     spec <- getVersionSpecFromQuery
     preferMin <- versionPriorityFromQueryIsMin

--- a/src/Handler/Package/V1/Index.hs
+++ b/src/Handler/Package/V1/Index.hs
@@ -123,9 +123,7 @@ getPackageIndexR = do
         getOsVersionCompat <&> \case
             Nothing -> const True
             Just v -> flip satisfies v
-    pkgArch <- getPkgArch >>= \case
-        Nothing -> pure []
-        Just a -> pure a
+    pkgArch <- getPkgArch
     ram <- getRamQuery
     hardwareDevices <- getHardwareDevicesQuery
     communityVersion <- getsYesod $ communityVersion . appSettings

--- a/src/Handler/Package/V1/Index.hs
+++ b/src/Handler/Package/V1/Index.hs
@@ -138,7 +138,7 @@ getPackageIndexR = do
     let (source, packageRanges) = case pkgIds of
             Nothing -> (serviceQuerySource category query pkgArch ram, const Any)
             Just packages ->
-                let s = getPkgDataSource (packageReqId <$> packages) pkgArch
+                let s = getPkgDataSource (packageReqId <$> packages) pkgArch ram
                     r = fromMaybe None . (flip lookup $ (packageReqId &&& packageReqVersion) <$> packages)
                 in (s, r)
     filteredPackages <-

--- a/src/Handler/Util.hs
+++ b/src/Handler/Util.hs
@@ -252,5 +252,4 @@ areRegexMatchesEqual textMap (PackageDevice regexMap) =
     checkMatch :: (Text, RegexPattern) -> Bool
     checkMatch (key, regexPattern) = 
         case MM.lookup key textMap of
-            _ : xs -> or $ regexMatch regexPattern <$> xs
-            []   -> False
+            val -> or $ regexMatch regexPattern <$> val

--- a/src/Lib/External/AppMgr.hs
+++ b/src/Lib/External/AppMgr.hs
@@ -105,23 +105,23 @@ sourceManifest ::
     (ConduitT () ByteString m () -> m r) ->
     m r
 sourceManifest appmgrPath pkgFile sink = do
-    let appmgr = readProcessInheritStderr (appmgrPath </> "embassy-sdk") ["inspect", "manifest", pkgFile] ""
+    let appmgr = readProcessInheritStderr (appmgrPath </> "start-sdk") ["inspect", "manifest", pkgFile] ""
     appmgr sink `catch` \ece ->
-        $logErrorSH ece *> throwIO (AppMgrE [i|embassy-sdk inspect manifest #{pkgFile}|] (eceExitCode ece))
+        $logErrorSH ece *> throwIO (AppMgrE [i|start-sdk inspect manifest #{pkgFile}|] (eceExitCode ece))
 
 
 sourceIcon :: (MonadUnliftIO m, MonadLoggerIO m) => FilePath -> FilePath -> (ConduitT () ByteString m () -> m r) -> m r
 sourceIcon appmgrPath pkgFile sink = do
-    let appmgr = readProcessInheritStderr (appmgrPath </> "embassy-sdk") ["inspect", "icon", pkgFile] ""
+    let appmgr = readProcessInheritStderr (appmgrPath </> "start-sdk") ["inspect", "icon", pkgFile] ""
     appmgr sink `catch` \ece ->
-        $logErrorSH ece *> throwIO (AppMgrE [i|embassy-sdk inspect icon #{pkgFile}|] (eceExitCode ece))
+        $logErrorSH ece *> throwIO (AppMgrE [i|start-sdk inspect icon #{pkgFile}|] (eceExitCode ece))
 
 
 getPackageHash :: (MonadUnliftIO m, MonadLoggerIO m) => FilePath -> FilePath -> m ByteString
 getPackageHash appmgrPath pkgFile = do
-    let appmgr = readProcessInheritStderr (appmgrPath </> "embassy-sdk") ["inspect", "hash", pkgFile] ""
+    let appmgr = readProcessInheritStderr (appmgrPath </> "start-sdk") ["inspect", "hash", pkgFile] ""
     appmgr (\bsSource -> runConduit $ bsSource .| CL.foldMap id) `catch` \ece ->
-        $logErrorSH ece *> throwIO (AppMgrE [i|embassy-sdk inspect hash #{pkgFile}|] (eceExitCode ece))
+        $logErrorSH ece *> throwIO (AppMgrE [i|start-sdk inspect hash #{pkgFile}|] (eceExitCode ece))
 
 
 sourceInstructions ::
@@ -131,9 +131,9 @@ sourceInstructions ::
     (ConduitT () ByteString m () -> m r) ->
     m r
 sourceInstructions appmgrPath pkgFile sink = do
-    let appmgr = readProcessInheritStderr (appmgrPath </> "embassy-sdk") ["inspect", "instructions", pkgFile] ""
+    let appmgr = readProcessInheritStderr (appmgrPath </> "start-sdk") ["inspect", "instructions", pkgFile] ""
     appmgr sink `catch` \ece ->
-        $logErrorSH ece *> throwIO (AppMgrE [i|embassy-sdk inspect instructions #{pkgFile}|] (eceExitCode ece))
+        $logErrorSH ece *> throwIO (AppMgrE [i|start-sdk inspect instructions #{pkgFile}|] (eceExitCode ece))
 
 
 sourceLicense ::
@@ -143,6 +143,6 @@ sourceLicense ::
     (ConduitT () ByteString m () -> m r) ->
     m r
 sourceLicense appmgrPath pkgFile sink = do
-    let appmgr = readProcessInheritStderr (appmgrPath </> "embassy-sdk") ["inspect", "license", pkgFile] ""
+    let appmgr = readProcessInheritStderr (appmgrPath </> "start-sdk") ["inspect", "license", pkgFile] ""
     appmgr sink `catch` \ece ->
-        $logErrorSH ece *> throwIO (AppMgrE [i|embassy-sdk inspect license #{pkgFile}|] (eceExitCode ece))
+        $logErrorSH ece *> throwIO (AppMgrE [i|start-sdk inspect license #{pkgFile}|] (eceExitCode ece))

--- a/src/Lib/Types/Core.hs
+++ b/src/Lib/Types/Core.hs
@@ -59,7 +59,6 @@ import Web.HttpApiData (
 import Yesod (PathPiece (..))
 import Prelude (read)
 
-
 newtype PkgId = PkgId {unPkgId :: Text}
     deriving stock (Eq, Ord)
     deriving newtype (FromHttpApiData, ToHttpApiData)

--- a/src/Lib/Types/Core.hs
+++ b/src/Lib/Types/Core.hs
@@ -27,7 +27,7 @@ import Startlude (
     show,
     symbolVal,
     ($),
-    (.), Enum,
+    (.), Enum, Applicative (..),
  )
 
 import Data.Aeson (
@@ -57,7 +57,8 @@ import Web.HttpApiData (
     ToHttpApiData,
  )
 import Yesod (PathPiece (..))
-import Prelude (read)
+import Prelude (read, fail)
+import Data.Aeson.Types (withText)
 
 newtype PkgId = PkgId {unPkgId :: Text}
     deriving stock (Eq, Ord)
@@ -111,7 +112,14 @@ instance PersistField OsArch where
 instance PersistFieldSql OsArch where
     sqlType _ = SqlString
 instance FromJSON OsArch where
-    parseJSON = parseJSON
+    parseJSON = withText "OsArch" $ \case
+        "x86_64"         -> pure X86_64
+        "aarch64"        -> pure AARCH64
+        "raspberrypi"    -> pure RASPBERRYPI
+        "rasberrypi"    -> pure RASPBERRYPI
+        "x86_64-nonfree" -> pure X86_64_NONFREE
+        "arch64-nonfree"-> pure AARCH64_NONFREE
+        _                -> fail "Invalid OsArch value"
 instance ToJSON OsArch where
     toJSON = toJSON
 

--- a/src/Lib/Types/Emver.hs
+++ b/src/Lib/Types/Emver.hs
@@ -73,7 +73,7 @@ import           Startlude                      ( ($)
                                                 )
 
 import           Control.Monad.Fail             ( fail )
-import           Data.Aeson                     ( ToJSONKey )
+import           Data.Aeson                     ( ToJSONKey, toJSON, Value(String))
 import qualified Data.Attoparsec.Text          as Atto
 import qualified Data.Text                     as T
 import           GHC.Base                       ( error )
@@ -81,9 +81,13 @@ import qualified GHC.Read                      as GHC
                                                 ( readsPrec )
 import qualified GHC.Show                      as GHC
                                                 ( show )
+import Dhall (Generic)
+import Data.Aeson.Types (ToJSON)
 
 -- | AppVersion is the core representation of the SemverQuad type.
-newtype Version = Version { unVersion :: (Word, Word, Word, Word) } deriving (Eq, Ord, ToJSONKey, Hashable)
+newtype Version = Version { unVersion :: (Word, Word, Word, Word) } deriving (Eq, Ord, Generic, ToJSONKey, Hashable)
+instance ToJSON Version where
+    toJSON = String . show
 instance Show Version where
     show (Version (x, y, z, q)) =
         let postfix = if q == 0 then "" else '.' : GHC.show q

--- a/src/Lib/Types/Manifest.hs
+++ b/src/Lib/Types/Manifest.hs
@@ -111,10 +111,10 @@ testManifest =
   },
   "hardware-requirements" {
     "device": {
-      "processor": "intel",
-      "display": "r'^{.*}$'"
+      "processor": "^[A-Za-z0-9]+$",
+      "display": "^[A-Za-z0-9]+$"
     },
-    "ram": "8"
+    "ram": "8000000000"
   }
   "assets": {
     "license": "LICENSE",

--- a/src/Lib/Types/Manifest.hs
+++ b/src/Lib/Types/Manifest.hs
@@ -111,8 +111,8 @@ testManifest =
   },
   "hardware-requirements" {
     "device": {
-      processor: "",
-      display: ""
+      processor: "intel",
+      display: "r'^{.*}$'"
     },
     "ram": "8"
 

--- a/src/Lib/Types/Manifest.hs
+++ b/src/Lib/Types/Manifest.hs
@@ -107,10 +107,11 @@ instance ToJSON PackageDevice where
         toKeyValue (key, value) = fromText key .= toJSON value
 instance FromJSON PackageDevice where
     parseJSON = withObject "PackageDevice" $ \obj -> do
-        hashMap <- parseJSON (Object obj)
+        hashMap <- obj .: ""
         pure $ PackageDevice hashMap
 
 instance PersistField PackageDevice where
+    toPersistValue :: PackageDevice -> PersistValue
     toPersistValue = PersistText . T.pack . show . toJSON
     fromPersistValue (PersistText t) = case eitherDecodeStrict (TE.encodeUtf8 t) of
         Left err -> Left $ T.pack err

--- a/src/Lib/Types/Manifest.hs
+++ b/src/Lib/Types/Manifest.hs
@@ -19,7 +19,7 @@ import Data.Aeson
       withObject,
       withText,
       FromJSON(parseJSON),
-      ToJSON(toJSON) )
+      ToJSON(toJSON), encode )
 import Database.Persist.Sql ( PersistFieldSql(..) )
 import Database.Persist.Types (SqlType(..))
 import Database.Persist (PersistValue(..))
@@ -28,7 +28,6 @@ import Database.Persist.Class ( PersistField(..) )
 import Data.Maybe (maybe)
 import qualified Data.ByteString as BS
 import Yesod.Persist (LiteralType(Escaped))
-import Data.Aeson.Encode.Pretty (encodePretty)
 
 
 data PackageManifest = PackageManifest
@@ -102,11 +101,11 @@ instance ToJSON PackageDevice where
     toJSON = toJSON . unPackageDevice
 
 instance PersistField PackageDevice where
-    toPersistValue =  PersistLiteral_  Escaped . BS.toStrict . encodePretty
-    fromPersistValue (PersistLiteral t) = case eitherDecodeStrict t of
+    toPersistValue =  PersistLiteral_ Escaped . BS.toStrict . encode
+    fromPersistValue (PersistByteString t) = case eitherDecodeStrict t of
         Left err -> Left $ T.pack err
         Right val -> Right val
-    fromPersistValue _ = Left "Invalid JSON value in database"
+    fromPersistValue _ = Left "Invalid JSON value in database ERR"
 
 instance PersistFieldSql PackageDevice where
     sqlType _ = SqlOther "JSONB"

--- a/src/Lib/Types/Manifest.hs
+++ b/src/Lib/Types/Manifest.hs
@@ -11,11 +11,9 @@ import Data.String.Interpolate.IsString (i)
 import Data.Text qualified as T
 import Lib.Types.Core (PkgId, OsArch)
 import Lib.Types.Emver (Version (..), VersionRange)
-import Startlude (ByteString, Eq, Generic, Hashable, Maybe (..), Monad ((>>=)), Read, Show, Text, for, pure, readMaybe, ($), Int, (.), (<>), String, map, otherwise, show)
+import Startlude (ByteString, Eq, Generic, Hashable, Maybe (..), Monad ((>>=)), Read, Show, Text, for, pure, readMaybe, ($), Int, (.), map, otherwise, show)
 import Data.Aeson
-    ( eitherDecode,
-      eitherDecodeStrict,
-      encode,
+    ( eitherDecodeStrict,
       (.:),
       (.:?),
       withObject,
@@ -28,7 +26,6 @@ import Data.Aeson
 import Database.Persist.Sql ( PersistFieldSql(..) )
 import Database.Persist.Types (SqlType(..))
 import qualified Data.Text.Encoding as TE
-import qualified Data.ByteString.Lazy as BL
 import Database.Persist (PersistValue(..))
 import Data.Either (Either(..))
 import Database.Persist.Class ( PersistField(..) )

--- a/src/Lib/Types/Manifest.hs
+++ b/src/Lib/Types/Manifest.hs
@@ -111,11 +111,10 @@ testManifest =
   },
   "hardware-requirements" {
     "device": {
-      processor: "intel",
-      display: "r'^{.*}$'"
+      "processor": "intel",
+      "display": "r'^{.*}$'"
     },
     "ram": "8"
-
   }
   "assets": {
     "license": "LICENSE",

--- a/src/Lib/Types/Manifest.hs
+++ b/src/Lib/Types/Manifest.hs
@@ -9,7 +9,7 @@ import Data.HashMap.Internal.Strict (HashMap)
 import Data.HashMap.Strict qualified as HM
 import Data.String.Interpolate.IsString (i)
 import Data.Text qualified as T
-import Lib.Types.Core (PkgId)
+import Lib.Types.Core (PkgId, OsArch)
 import Lib.Types.Emver (Version (..), VersionRange)
 import Startlude (ByteString, Eq, Generic, Hashable, Maybe (..), Monad ((>>=)), Read, Show, Text, for, pure, readMaybe, ($), Int, (.), (<>))
 import Data.Aeson
@@ -34,6 +34,7 @@ data PackageManifest = PackageManifest
     , packageManifestEosVersion :: !Version
     , packageHardwareDevice :: !(Maybe PackageDevice)
     , packageHardwareRam :: !(Maybe Int)
+    , packageHardwareArch :: !(Maybe [OsArch])
     }
     deriving (Show)
 instance FromJSON PackageManifest where
@@ -57,6 +58,7 @@ instance FromJSON PackageManifest where
         packageManifestEosVersion <- o .: "eos-version"
         packageHardwareDevice <- o .: "hardware-requirements" >>= (.: "device")
         packageHardwareRam <- o .: "hardware-requirements" >>= (.: "ram")
+        packageHardwareArch <- o .: "hardware-requirements" >>= (.: "arch")
         pure PackageManifest{..}
 
 
@@ -114,7 +116,8 @@ testManifest =
       "processor": "^[A-Za-z0-9]+$",
       "display": "^[A-Za-z0-9]+$"
     },
-    "ram": "8000000000"
+    "ram": "8000000000",
+    "arch": ["aarch64", "x86_64"]
   }
   "assets": {
     "license": "LICENSE",

--- a/src/Lib/Types/Manifest.hs
+++ b/src/Lib/Types/Manifest.hs
@@ -11,7 +11,7 @@ import Data.String.Interpolate.IsString (i)
 import Data.Text qualified as T
 import Lib.Types.Core (PkgId, OsArch)
 import Lib.Types.Emver (Version (..), VersionRange)
-import Startlude (ByteString, Eq, Generic, Hashable, Maybe (..), Monad ((>>=)), Read, Show, Text, for, pure, readMaybe, ($), Int, (.), map, otherwise, show)
+import Startlude (ByteString, Eq, Generic, Hashable, Maybe (..), Monad ((>>=)), Read, Show, Text, for, pure, readMaybe, ($), Int, (.), map, otherwise, show, String)
 import Data.Aeson
     ( eitherDecodeStrict,
       (.:),
@@ -20,7 +20,6 @@ import Data.Aeson
       withText,
       object,
       FromJSON(parseJSON),
-      Value(Object),
       KeyValue((.=)),
       ToJSON(toJSON) )
 import Database.Persist.Sql ( PersistFieldSql(..) )
@@ -31,6 +30,7 @@ import Data.Either (Either(..))
 import Database.Persist.Class ( PersistField(..) )
 import Data.Aeson.Key ( fromText )
 import Data.Maybe (maybe)
+import Data.Aeson.Types (Value(Object))
 
 
 data PackageManifest = PackageManifest
@@ -107,7 +107,7 @@ instance ToJSON PackageDevice where
         toKeyValue (key, value) = fromText key .= toJSON value
 instance FromJSON PackageDevice where
     parseJSON = withObject "PackageDevice" $ \obj -> do
-        hashMap <- obj .: ""
+        hashMap <- parseJSON (Object obj)
         pure $ PackageDevice hashMap
 
 instance PersistField PackageDevice where
@@ -125,6 +125,7 @@ data ServiceAlert = INSTALL | UNINSTALL | RESTORE | START | STOP
 
 
 -- >>> eitherDecodeStrict testManifest :: Either String PackageManifest
+-- Right (PackageManifest {packageManifestId = embassy-pages, packageManifestTitle = "Embassy Pages", packageManifestVersion = 0.1.3, packageManifestDescriptionLong = "Embassy Pages is a simple web server that uses directories inside File Browser to serve Tor websites.", packageManifestDescriptionShort = "Create Tor websites, hosted on your Embassy.", packageManifestReleaseNotes = "Upgrade to EmbassyOS v0.3.0", packageManifestIcon = Just "icon.png", packageManifestAlerts = fromList [(STOP,Nothing),(RESTORE,Nothing),(INSTALL,Nothing),(START,Nothing),(UNINSTALL,Nothing)], packageManifestDependencies = fromList [(filebrowser,PackageDependency {packageDependencyOptional = Nothing, packageDependencyVersion = >=2.14.1.1 <3.0.0, packageDependencyDescription = Just "Used to upload files to serve."})], packageManifestEosVersion = 0.3.0, packageHardwareDevice = Just (PackageDevice (fromList [("processor",RegexPattern "^[A-Za-z0-9]+$"),("display",RegexPattern "^[A-Za-z0-9]+$")])), packageHardwareRam = Just 8000000000, packageHardwareArch = Just [aarch64,x86_64]})
 testManifest :: ByteString
 testManifest =
     [i|{

--- a/src/Model.hs
+++ b/src/Model.hs
@@ -29,6 +29,7 @@ import Lib.Types.Emver (
  )
 import Orphans.Cryptonite ()
 import Orphans.Emver ()
+import Orphans.Value ()
 import Startlude (
     Eq,
     Int,
@@ -36,8 +37,9 @@ import Startlude (
     Text,
     UTCTime,
     Word32,
-    Bool
+    Bool,
  )
+import Lib.Types.Manifest (PackageDevice)
 
 
 share
@@ -72,8 +74,10 @@ VersionPlatform
     updatedAt UTCTime Maybe
     pkgId PkgRecordId
     versionNumber Version
-    arch OsArch
-    Primary pkgId versionNumber arch
+    ram Int Maybe
+    device PackageDevice Maybe
+    arch OsArch Maybe
+    Primary pkgId versionNumber
     deriving Eq
     deriving Show
 

--- a/src/Model.hs
+++ b/src/Model.hs
@@ -29,7 +29,6 @@ import Lib.Types.Emver (
  )
 import Orphans.Cryptonite ()
 import Orphans.Emver ()
-import Orphans.Value ()
 import Startlude (
     Eq,
     Int,

--- a/src/Model.hs
+++ b/src/Model.hs
@@ -76,8 +76,8 @@ VersionPlatform
     versionNumber Version
     ram Int Maybe
     device PackageDevice Maybe
-    arch OsArch Maybe
-    Primary pkgId versionNumber
+    arch OsArch
+    Primary pkgId versionNumber arch
     deriving Eq
     deriving Show
 

--- a/src/Orphans/Emver.hs
+++ b/src/Orphans/Emver.hs
@@ -35,8 +35,6 @@ import           Lib.Types.Emver                ( Version
 
 instance FromJSON Version where
     parseJSON = withText "Emver Version" $ either fail pure . Atto.parseOnly parseVersion
-instance ToJSON Version where
-    toJSON = String . show
 instance FromJSON VersionRange where
     parseJSON = withText "Emver" $ either fail pure . Atto.parseOnly parseRange
 instance ToJSON VersionRange where


### PR DESCRIPTION
Actually quite a massive PR as this change affected a lot. The main logic is in fetching the new query params, and `filterDevices`. There is some refactor with changes to the DB model.

The first commit is for the changes to the publish script for adding/removing arches for a package. The second commit is the API changes. Other commits are fixes.

This is now well tested with no known issues and full backwards compatibility. 
